### PR TITLE
Eliminate crash in 'captureOutput'

### DIFF
--- a/CapturingPhotosSwift6/CapturingPhotosSwift6/Camera.swift
+++ b/CapturingPhotosSwift6/CapturingPhotosSwift6/Camera.swift
@@ -347,11 +347,15 @@ extension Camera: AVCapturePhotoCaptureDelegate {
 extension Camera: AVCaptureVideoDataOutputSampleBufferDelegate {
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
         guard let pixelBuffer = sampleBuffer.imageBuffer else { return }
+
+        dispatchPrecondition(condition: .notOnQueue(.main))
         
-        // if connection.isVideoOrientationSupported,
-        //    let videoOrientation = videoOrientationFor(deviceOrientation) {
-        //     connection.videoOrientation = videoOrientation
-        // }
+        if
+            connection.isVideoOrientationSupported,
+            let videoOrientation = videoOrientationFor(DispatchQueue.main.sync { deviceOrientation })
+        {
+            connection.videoOrientation = videoOrientation
+        }
 
         addToPreviewStream?(CIImage(cvPixelBuffer: pixelBuffer))
     }

--- a/CapturingPhotosSwift6/CapturingPhotosSwift6/Camera.swift
+++ b/CapturingPhotosSwift6/CapturingPhotosSwift6/Camera.swift
@@ -344,16 +344,14 @@ extension Camera: AVCapturePhotoCaptureDelegate {
     }
 }
 
-extension Camera: @preconcurrency AVCaptureVideoDataOutputSampleBufferDelegate {
-    
-    @MainActor
+extension Camera: AVCaptureVideoDataOutputSampleBufferDelegate {
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
         guard let pixelBuffer = sampleBuffer.imageBuffer else { return }
         
-        if connection.isVideoOrientationSupported,
-           let videoOrientation = videoOrientationFor(deviceOrientation) {
-            connection.videoOrientation = videoOrientation
-        }
+        // if connection.isVideoOrientationSupported,
+        //    let videoOrientation = videoOrientationFor(deviceOrientation) {
+        //     connection.videoOrientation = videoOrientation
+        // }
 
         addToPreviewStream?(CIImage(cvPixelBuffer: pixelBuffer))
     }


### PR DESCRIPTION
* Remove `@preconcurrency` qualifier to `AVCaptureVideoDataOutputSampleBufferDelegate` conformance.
* Remove `@MainActor` qualifier from `captureOutput` method.